### PR TITLE
Blocking sb.music.apple.com breaks some Apple Music functionality

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -1002,7 +1002,6 @@ s4.mzstatic.com
 s5.mzstatic.com
 sandbox.itunes.apple.com
 sandbox.itunes-apple.com.akadns.net
-sb.music.apple.com
 sb.tv.apple.com
 se2.itunes.apple.com
 se-applak.itunes-apple.com.akadns.net


### PR DESCRIPTION
With sb.music.apple.com blocked you won't be able to access "Listen Now", "Browse", "Radio" pages (and maybe something else) in Apple Music app